### PR TITLE
Batch process leads to get around timeout

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,16 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+node_modules


### PR DESCRIPTION
* The ‘X-RateLimit-Reset’ header gives the time when the rate limit will reset. I used this to make the sleep smarter. See: https://medium.com/@guillaume.viguierjust/rate-limiting-your-restful-api-3148f8e77248
* Running multiple cloud functions in parallel caused a race condition if the prod table didn’t exist in BigQuery. The previous code would check if the table exists and create it if not, but if two function instances both tried to create it the slower one would get an error because of the write disposition. I got around it with some extra checking around Exceptions.
* A batch size of 1000 still caused a timeout. A batch size of 500 worked well for a 30 day input (43200 minutes). It could probably be tuned further, and it may need to be adjusted if a different time input is given. 
* Calling the cloud function initially works the same as before: send it a string with a number of minutes in the message. The new, recursive entry point looks for a JSON object with a ‘batch_num’ field to identify which batch of leads is being processed, and a  ‘leads’ field that contains a list of leads as objects with an ‘Id’ field. 
